### PR TITLE
Remove some options.

### DIFF
--- a/build_linux/Makefile.env
+++ b/build_linux/Makefile.env
@@ -15,7 +15,6 @@ WFLAGS			+= -Wunknown-pragmas
 WFLAGS			+= -Wimplicit-int
 WFLAGS			+= -Wtrigraphs
 WFLAGS			+= -std=gnu99
-WFLAGS			+= -mtune=native -march=native -mfpmath=both 
 
 #
 # Define flags


### PR DESCRIPTION
Some options should be removed.

* Some versions of Clang doesn't support `-march=native`.
* `-mfpmath=both` is only supported by x86_64-gcc. And it will be the default value on x86_64-gcc
* They are not a warning related option. 