### PR TITLE
リリース用のGitHub Actionsをマルチターゲットに対応

### DIFF
--- a/.github/workflows/packagebuild.yml
+++ b/.github/workflows/packagebuild.yml
@@ -77,6 +77,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-targets-job]
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}

--- a/.github/workflows/packagebuild.yml
+++ b/.github/workflows/packagebuild.yml
@@ -111,6 +111,6 @@ jobs:
           draft: true
           prerelease: true
           files: |
-            *.tar.gz
+            ./athrill-targets/*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/packagebuild.yml
+++ b/.github/workflows/packagebuild.yml
@@ -7,25 +7,67 @@ on:
       - 'RC*'
 
 jobs:
-  build:
-    runs-on: ubuntu-18.04
+  packagebuild:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
     steps:
+      - name: Setup cmake
+        uses: jwlawson/actions-setup-cmake@v1.12
+        with:
+          github-api-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
           submodules: true  # Fetch athrill repo
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+        
+      - name: Checkout toppers utils
+        run:  git clone https://github.com/mitsut/toppers_utils.git
 
-      - name: Build athrill
+      - name: Build athrill for Linux or Mac
+        if:  " (matrix.os == 'ubuntu-latest') || (matrix.os == 'macos-latest') " 
         run: |
-          cd build_linux
+          mkdir build
+          cd build
+          cmake -H.. 
           make
+          ./athrill2
+      
+      - name: Setup MinGW for Windows and build athrill for Windows
+        if:  matrix.os == 'windows-latest'
+        uses: egor-tensin/setup-mingw@v2
+        run: |
+          mkdir build_win
+          mkdir build
+          cd build
+          cmake -G"MinGW Makefiles" ..
+          make
+          .\athrill2.exe
+
+      - name: Move to build folder(linux)
+        if:  matrix.os == 'ubuntu-latest'
+        run: |
+          cp build/athrill2 build_linux/
+          perl toppers_utils/makerelease E_PACKAGE
+      - name: Move to build folder(mac)
+        if:  matrix.os == 'macos-latest'
+        run: |
+          cp build/athrill2 build_mac/
+          perl toppers_utils/makerelease E_PACKAGE.darwin
+      - name: Move to build folder(win)
+        if:  matrix.os == 'windows-latest'
+        run: |
+          cp build/athrill2.exe build_win/
+          perl toppers_utils/makerelease E_PACKAGE.win
 
       - name: Archive package
         id: get_archive
         run: |
-          git clone https://github.com/mitsut/toppers_utils.git
-          perl toppers_utils/makerelease E_PACKAGE
+          ls -la RELEASE/
           FILE_NAME="$(ls -1 RELEASE/ | sed -n 1p)"
           echo ::set-output name=FILE_NAME::${FILE_NAME}
 

--- a/.github/workflows/packagebuild.yml
+++ b/.github/workflows/packagebuild.yml
@@ -37,9 +37,12 @@ jobs:
           make
           ./athrill2
       
-      - name: Setup MinGW for Windows and build athrill for Windows
+      - name: Setup MinGW for Windows
         if:  matrix.os == 'windows-latest'
         uses: egor-tensin/setup-mingw@v2
+
+      - name: Build athrill for Windows
+        if:  matrix.os == 'windows-latest'
         run: |
           mkdir build_win
           mkdir build

--- a/.github/workflows/packagebuild.yml
+++ b/.github/workflows/packagebuild.yml
@@ -7,7 +7,7 @@ on:
       - 'RC*'
 
 jobs:
-  packagebuild:
+  build-targets-job:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -67,12 +67,16 @@ jobs:
           cp build/athrill2.exe build_win/
           perl toppers_utils/makerelease E_PACKAGE.win
 
-      - name: Archive package
-        id: get_archive
-        run: |
-          FILE_NAME="$(ls -1 RELEASE/ | sed -n 1p)"
-          echo ::set-output name=FILE_NAME::${FILE_NAME}
-
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: athrill-targets
+          path: RELEASE/*.tar.gz
+  
+  MakeRelease:
+    runs-on: ubuntu-latest
+    needs: [build-targets-job]
+    steps:
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
@@ -86,27 +90,24 @@ jobs:
           COMMIT_SUMMARY="${COMMIT_SUMMARY//$'\n'/'%0A'}"
           echo ::set-output name=COMMIT_SUMMARY::$COMMIT_SUMMARY
 
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Display structure of downloaded files
+        run: ls -R
+
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
           tag_name: ${{ steps.get_version.outputs.VERSION }}
-          release_name: Release ${{ steps.get_version.outputs.VERSION }}
+          name: Release ${{ steps.get_version.outputs.VERSION }}
           body: |
             ${{ steps.get_commit_summary.outputs.COMMIT_SUMMARY }}
           draft: true
           prerelease: true
-
-      - uses: actions/upload-release-asset@master
+          files: |
+            *.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          # 添付ファイルのパス (必須)
-          asset_path: ./RELEASE/${{ steps.get_archive.outputs.FILE_NAME }}
-          # 添付ファイルの表示名 (必須)
-          asset_name: ${{ steps.get_archive.outputs.FILE_NAME }}
-          # 添付ファイルに対応する content-type (必須)
-          asset_content_type: application/zip

--- a/.github/workflows/packagebuild.yml
+++ b/.github/workflows/packagebuild.yml
@@ -70,7 +70,6 @@ jobs:
       - name: Archive package
         id: get_archive
         run: |
-          ls -la RELEASE/
           FILE_NAME="$(ls -1 RELEASE/ | sed -n 1p)"
           echo ::set-output name=FILE_NAME::${FILE_NAME}
 

--- a/E_PACKAGE.darwin
+++ b/E_PACKAGE.darwin
@@ -1,4 +1,4 @@
-E_PACKAGE athrill-target-ARMv7-A-x86_64-linux
+E_PACKAGE athrill-target-ARMv7-A-x86_64-darwin
 VERSION %date
 
 INCLUDE MANIFEST

--- a/E_PACKAGE.darwin
+++ b/E_PACKAGE.darwin
@@ -4,4 +4,4 @@ VERSION %date
 INCLUDE MANIFEST
 INCLUDE ../athrill/MANIFEST
 
-build_linux/athrill2
+build_mac/athrill2

--- a/E_PACKAGE.win
+++ b/E_PACKAGE.win
@@ -1,0 +1,7 @@
+E_PACKAGE athrill-target-ARMv7-A-x86_64-win
+VERSION %date
+
+INCLUDE MANIFEST
+INCLUDE ../athrill/MANIFEST
+
+build_win/athrill2.exe

--- a/MANIFEST
+++ b/MANIFEST
@@ -64,7 +64,6 @@ src/cpu/cpu_exec/op_exec_load.c
 src/cpu/cpu_exec/op_exec_load_pseudo.c
 src/cpu/cpu_exec/op_exec_logic.c
 src/cpu/cpu_exec/op_exec_logic_pseudo.c
-src/cpu/cpu_exec/op_exec_sat.c
 src/cpu/cpu_exec/op_exec_spec.c
 src/cpu/cpu_exec/op_exec_spec_pseudo.c
 src/cpu/cpu_exec/op_exec_store.c


### PR DESCRIPTION
マルチターゲットでのビルドができているので、リリース向けのGitHub Actionsを対応させました。

併せて次のように変更しました。
- E_PACKAGEをターゲットごとに用意して、ターゲット別のバイナリアーカイブを作成した（リリースページからダウンロード）
- [actions/create-release](https://github.com/actions/create-release) と　[actions/upload-release-asset](https://github.com/actions/upload-release-asset)がメンテナンス終了したので、[action-gh-release](https://github.com/softprops/action-gh-release)へ変更した
- ビルドはターゲットごとにjobを並列実行させて、MakeReleaseを別jobにしてターゲットごとのアーティファクトをまとめた
- job間のアーティファクトの受け渡しは、 `actions/upload-artifact` `actions/download-artifact` を使用しました
